### PR TITLE
feat: Update widgets to support custom fonts

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -41,6 +41,7 @@
       width: 100%;
       background: rgba(0,0,0,0.2);
       color: var(--text);
+      font-family: var(--font-header, system-ui, sans-serif);
       font-size: 2.5rem;
       text-align: right;
       padding: 12px 16px;
@@ -55,6 +56,7 @@
       gap: 12px;
     }
     .calc-btn {
+      font-family: var(--font-body, system-ui, sans-serif);
       background: rgba(255, 255, 255, 0.05);
       border: 1px solid rgba(255, 255, 255, 0.1);
       color: var(--text);
@@ -119,13 +121,47 @@
     const params = new URLSearchParams(window.location.search);
     const root = document.documentElement;
 
-    // Apply theme colors
-    ['primary', 'secondary', 'accent', 'surface', 'text'].forEach(color => {
+    // 1. Apply Theme Colors
+    const themeColors = ['primary', 'secondary', 'accent', 'surface', 'text'];
+    themeColors.forEach(color => {
       const value = params.get(color);
       if (value) {
         root.style.setProperty(`--${color}`, value);
       }
     });
+
+    // 2. Load and Apply Fonts
+    const fontHeader = params.get('fontHeader');
+    const fontSubheader = params.get('fontSubheader');
+    const fontBody = params.get('fontBody');
+
+    // Create a Google Fonts URL from the font families provided
+    const fontsToLoad = [fontHeader, fontSubheader, fontBody]
+      .filter(Boolean) // Remove null/undefined entries
+      .filter((font, index, self) => self.indexOf(font) === index); // Get unique fonts
+
+    if (fontsToLoad.length > 0) {
+      const fontUrl = `https://fonts.googleapis.com/css2?family=${fontsToLoad.map(f => f.replace(/ /g, '+')).join('&family=')}&display=swap`;
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = fontUrl;
+      document.head.appendChild(link);
+    }
+
+    // 3. Set CSS Custom Properties for Fonts
+    const style = document.createElement('style');
+    style.innerHTML = `
+      :root {
+        --font-header: "${fontHeader || 'system-ui, sans-serif'}";
+        --font-subheader: "${fontSubheader || 'system-ui, sans-serif'}";
+        --font-body: "${fontBody || 'system-ui, sans-serif'}";
+      }
+
+      h1, h2, h3, .font-header { font-family: var(--font-header); }
+      h4, h5, h6, .font-subheader { font-family: var(--font-subheader); }
+      body, p, div, span, a { font-family: var(--font-body); }
+    `;
+    document.head.appendChild(style);
 
     const display = document.getElementById('display');
     const keys = document.querySelector('.calculator-keys');

--- a/calendar.html
+++ b/calendar.html
@@ -56,6 +56,7 @@
       color: var(--primary);
     }
     .calendar-month-year {
+      font-family: var(--font-header, system-ui, sans-serif);
       font-size: 1.1rem;
       font-weight: 600;
       color: var(--primary);
@@ -67,12 +68,14 @@
       text-align: center;
     }
     .calendar-day-name {
+      font-family: var(--font-subheader, system-ui, sans-serif);
       font-size: 0.75rem;
       font-weight: 500;
       opacity: 0.6;
       padding-bottom: 8px;
     }
     .calendar-day {
+      font-family: var(--font-body, system-ui, sans-serif);
       font-size: 0.875rem;
       padding: 4px;
       border-radius: 50%;
@@ -115,13 +118,47 @@
     const params = new URLSearchParams(window.location.search);
     const root = document.documentElement;
 
-    // Apply theme colors
-    ['primary', 'secondary', 'accent', 'surface', 'text'].forEach(color => {
+    // 1. Apply Theme Colors
+    const themeColors = ['primary', 'secondary', 'accent', 'surface', 'text'];
+    themeColors.forEach(color => {
       const value = params.get(color);
       if (value) {
         root.style.setProperty(`--${color}`, value);
       }
     });
+
+    // 2. Load and Apply Fonts
+    const fontHeader = params.get('fontHeader');
+    const fontSubheader = params.get('fontSubheader');
+    const fontBody = params.get('fontBody');
+
+    // Create a Google Fonts URL from the font families provided
+    const fontsToLoad = [fontHeader, fontSubheader, fontBody]
+      .filter(Boolean) // Remove null/undefined entries
+      .filter((font, index, self) => self.indexOf(font) === index); // Get unique fonts
+
+    if (fontsToLoad.length > 0) {
+      const fontUrl = `https://fonts.googleapis.com/css2?family=${fontsToLoad.map(f => f.replace(/ /g, '+')).join('&family=')}&display=swap`;
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = fontUrl;
+      document.head.appendChild(link);
+    }
+
+    // 3. Set CSS Custom Properties for Fonts
+    const style = document.createElement('style');
+    style.innerHTML = `
+      :root {
+        --font-header: "${fontHeader || 'system-ui, sans-serif'}";
+        --font-subheader: "${fontSubheader || 'system-ui, sans-serif'}";
+        --font-body: "${fontBody || 'system-ui, sans-serif'}";
+      }
+
+      h1, h2, h3, .font-header { font-family: var(--font-header); }
+      h4, h5, h6, .font-subheader { font-family: var(--font-subheader); }
+      body, p, div, span, a { font-family: var(--font-body); }
+    `;
+    document.head.appendChild(style);
 
     // Widget configuration
     const config = {

--- a/clock.html
+++ b/clock.html
@@ -85,6 +85,7 @@
 
     /* Digital Clock Styles */
     .digital-clock {
+      font-family: var(--font-header, system-ui, sans-serif);
       font-size: 3rem;
       font-weight: 700;
       color: var(--primary);
@@ -107,13 +108,47 @@
     const params = new URLSearchParams(window.location.search);
     const root = document.documentElement;
 
-    // Apply theme colors
-    ['primary', 'secondary', 'accent', 'surface', 'text'].forEach(color => {
+    // 1. Apply Theme Colors
+    const themeColors = ['primary', 'secondary', 'accent', 'surface', 'text'];
+    themeColors.forEach(color => {
       const value = params.get(color);
       if (value) {
         root.style.setProperty(`--${color}`, value);
       }
     });
+
+    // 2. Load and Apply Fonts
+    const fontHeader = params.get('fontHeader');
+    const fontSubheader = params.get('fontSubheader');
+    const fontBody = params.get('fontBody');
+
+    // Create a Google Fonts URL from the font families provided
+    const fontsToLoad = [fontHeader, fontSubheader, fontBody]
+      .filter(Boolean) // Remove null/undefined entries
+      .filter((font, index, self) => self.indexOf(font) === index); // Get unique fonts
+
+    if (fontsToLoad.length > 0) {
+      const fontUrl = `https://fonts.googleapis.com/css2?family=${fontsToLoad.map(f => f.replace(/ /g, '+')).join('&family=')}&display=swap`;
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = fontUrl;
+      document.head.appendChild(link);
+    }
+
+    // 3. Set CSS Custom Properties for Fonts
+    const style = document.createElement('style');
+    style.innerHTML = `
+      :root {
+        --font-header: "${fontHeader || 'system-ui, sans-serif'}";
+        --font-subheader: "${fontSubheader || 'system-ui, sans-serif'}";
+        --font-body: "${fontBody || 'system-ui, sans-serif'}";
+      }
+
+      h1, h2, h3, .font-header { font-family: var(--font-header); }
+      h4, h5, h6, .font-subheader { font-family: var(--font-subheader); }
+      body, p, div, span, a { font-family: var(--font-body); }
+    `;
+    document.head.appendChild(style);
 
     // Widget configuration
     const config = {

--- a/notes.html
+++ b/notes.html
@@ -52,6 +52,7 @@
     }
     
     .notes-title {
+      font-family: var(--font-header, system-ui, sans-serif);
       font-size: 1.1rem;
       font-weight: 600;
       color: var(--primary);
@@ -82,6 +83,7 @@
       display: flex;
       align-items: center;
       gap: 4px;
+      font-family: var(--font-body, system-ui, sans-serif);
     }
     
     .action-btn:hover {
@@ -157,6 +159,7 @@
     }
     
     .preview-mode h1, .preview-mode h2, .preview-mode h3 {
+      font-family: var(--font-header, system-ui, sans-serif);
       color: var(--primary);
       margin-top: 1em;
       margin-bottom: 0.5em;
@@ -267,13 +270,47 @@
     const params = new URLSearchParams(window.location.search);
     const root = document.documentElement;
     
-    // Apply theme colors
-    ['primary', 'secondary', 'accent', 'surface', 'text'].forEach(color => {
+    // 1. Apply Theme Colors
+    const themeColors = ['primary', 'secondary', 'accent', 'surface', 'text'];
+    themeColors.forEach(color => {
       const value = params.get(color);
       if (value) {
         root.style.setProperty(`--${color}`, value);
       }
     });
+
+    // 2. Load and Apply Fonts
+    const fontHeader = params.get('fontHeader');
+    const fontSubheader = params.get('fontSubheader');
+    const fontBody = params.get('fontBody');
+
+    // Create a Google Fonts URL from the font families provided
+    const fontsToLoad = [fontHeader, fontSubheader, fontBody]
+      .filter(Boolean) // Remove null/undefined entries
+      .filter((font, index, self) => self.indexOf(font) === index); // Get unique fonts
+
+    if (fontsToLoad.length > 0) {
+      const fontUrl = `https://fonts.googleapis.com/css2?family=${fontsToLoad.map(f => f.replace(/ /g, '+')).join('&family=')}&display=swap`;
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = fontUrl;
+      document.head.appendChild(link);
+    }
+
+    // 3. Set CSS Custom Properties for Fonts
+    const style = document.createElement('style');
+    style.innerHTML = `
+      :root {
+        --font-header: "${fontHeader || 'system-ui, sans-serif'}";
+        --font-subheader: "${fontSubheader || 'system-ui, sans-serif'}";
+        --font-body: "${fontBody || 'system-ui, sans-serif'}";
+      }
+
+      h1, h2, h3, .font-header { font-family: var(--font-header); }
+      h4, h5, h6, .font-subheader { font-family: var(--font-subheader); }
+      body, p, div, span, a { font-family: var(--font-body); }
+    `;
+    document.head.appendChild(style);
     
     // Widget configuration from URL params
     const config = {

--- a/quote.html
+++ b/quote.html
@@ -35,6 +35,7 @@
       padding: 16px;
     }
     .quote-text {
+      font-family: var(--font-header, system-ui, sans-serif);
       font-size: 1.2rem;
       font-style: italic;
       color: var(--primary);
@@ -42,6 +43,7 @@
       line-height: 1.5;
     }
     .quote-author {
+      font-family: var(--font-body, system-ui, sans-serif);
       font-size: 0.9rem;
       font-weight: 600;
       color: var(--text);
@@ -62,13 +64,47 @@
     const params = new URLSearchParams(window.location.search);
     const root = document.documentElement;
 
-    // Apply theme colors
-    ['primary', 'secondary', 'accent', 'surface', 'text'].forEach(color => {
+    // 1. Apply Theme Colors
+    const themeColors = ['primary', 'secondary', 'accent', 'surface', 'text'];
+    themeColors.forEach(color => {
       const value = params.get(color);
       if (value) {
         root.style.setProperty(`--${color}`, value);
       }
     });
+
+    // 2. Load and Apply Fonts
+    const fontHeader = params.get('fontHeader');
+    const fontSubheader = params.get('fontSubheader');
+    const fontBody = params.get('fontBody');
+
+    // Create a Google Fonts URL from the font families provided
+    const fontsToLoad = [fontHeader, fontSubheader, fontBody]
+      .filter(Boolean) // Remove null/undefined entries
+      .filter((font, index, self) => self.indexOf(font) === index); // Get unique fonts
+
+    if (fontsToLoad.length > 0) {
+      const fontUrl = `https://fonts.googleapis.com/css2?family=${fontsToLoad.map(f => f.replace(/ /g, '+')).join('&family=')}&display=swap`;
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = fontUrl;
+      document.head.appendChild(link);
+    }
+
+    // 3. Set CSS Custom Properties for Fonts
+    const style = document.createElement('style');
+    style.innerHTML = `
+      :root {
+        --font-header: "${fontHeader || 'system-ui, sans-serif'}";
+        --font-subheader: "${fontSubheader || 'system-ui, sans-serif'}";
+        --font-body: "${fontBody || 'system-ui, sans-serif'}";
+      }
+
+      h1, h2, h3, .font-header { font-family: var(--font-header); }
+      h4, h5, h6, .font-subheader { font-family: var(--font-subheader); }
+      body, p, div, span, a { font-family: var(--font-body); }
+    `;
+    document.head.appendChild(style);
 
     // Widget configuration
     const config = {

--- a/weather.htm
+++ b/weather.htm
@@ -46,6 +46,7 @@
       margin-bottom: 16px;
     }
     .current-temp {
+      font-family: var(--font-header, system-ui, sans-serif);
       font-size: 2.5rem; /* Reduced font size */
       font-weight: 700;
       color: var(--primary);
@@ -55,10 +56,12 @@
       text-align: center; /* Center text for better wrapping */
     }
     .location {
+      font-family: var(--font-subheader, system-ui, sans-serif);
       font-size: 1.1rem; /* Reduced font size */
       font-weight: 600;
     }
     .condition {
+      font-family: var(--font-body, system-ui, sans-serif);
       font-size: 0.9rem; /* Reduced font size */
       opacity: 0.8;
     }
@@ -105,13 +108,47 @@
     const params = new URLSearchParams(window.location.search);
     const root = document.documentElement;
 
-    // Apply theme colors
-    ['primary', 'secondary', 'accent', 'surface', 'text'].forEach(color => {
+    // 1. Apply Theme Colors
+    const themeColors = ['primary', 'secondary', 'accent', 'surface', 'text'];
+    themeColors.forEach(color => {
       const value = params.get(color);
       if (value) {
         root.style.setProperty(`--${color}`, value);
       }
     });
+
+    // 2. Load and Apply Fonts
+    const fontHeader = params.get('fontHeader');
+    const fontSubheader = params.get('fontSubheader');
+    const fontBody = params.get('fontBody');
+
+    // Create a Google Fonts URL from the font families provided
+    const fontsToLoad = [fontHeader, fontSubheader, fontBody]
+      .filter(Boolean) // Remove null/undefined entries
+      .filter((font, index, self) => self.indexOf(font) === index); // Get unique fonts
+
+    if (fontsToLoad.length > 0) {
+      const fontUrl = `https://fonts.googleapis.com/css2?family=${fontsToLoad.map(f => f.replace(/ /g, '+')).join('&family=')}&display=swap`;
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = fontUrl;
+      document.head.appendChild(link);
+    }
+
+    // 3. Set CSS Custom Properties for Fonts
+    const style = document.createElement('style');
+    style.innerHTML = `
+      :root {
+        --font-header: "${fontHeader || 'system-ui, sans-serif'}";
+        --font-subheader: "${fontSubheader || 'system-ui, sans-serif'}";
+        --font-body: "${fontBody || 'system-ui, sans-serif'}";
+      }
+
+      h1, h2, h3, .font-header { font-family: var(--font-header); }
+      h4, h5, h6, .font-subheader { font-family: var(--font-subheader); }
+      body, p, div, span, a { font-family: var(--font-body); }
+    `;
+    document.head.appendChild(style);
 
     // Widget configuration
     const config = {


### PR DESCRIPTION
This commit updates all widgets to inherit and apply fonts from the host application, as per the new Widget Guide.

- Added a script to each widget to parse `fontHeader`, `fontSubheader`, and `fontBody` from URL parameters.
- The script dynamically generates a Google Fonts URL to load the specified fonts.
- CSS custom properties (`--font-header`, `--font-subheader`, `--font-body`) are created to hold the font family names.
- Updated widget CSS to use these new font variables, ensuring a consistent look and feel with the host application.

The following widgets have been updated:
- calculator.html
- calendar.html
- clock.html
- notes.html
- quote.html
- weather.htm